### PR TITLE
bugfix: $terms can be empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,15 @@ Search Everything plugin now includes a writing helper called Research Everythin
 
 ## Changelog
 
+** 8.2.1 **
+
+- This fixes a problem where $terms with no elements led to broken SQL code. This is the case in a wordpress installation with woocommerce plugin installed. Searching for orders led to broken SQL code because apparently the $terms array contains no elements in this case.
+
+### Previous Changelog
+
 ** 8.2 **
 
 - Removed external search because Zemata API doesn't seem to be available anymore which caused a fatal error on post publish
-
-### Previous Changelog
 
 ** 8.1.10 **
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: juliantroeps, sovrn, zemanta
 Tags: search, search highlight, tag search, category search, category exclusion, comment search, page search, admin, seo, post filter, research
 Requires at least: 3.6
-Tested up to: 5.2.2
-Stable tag: 8.1.10
+Tested up to: 5.4.2
+Stable tag: 8.2.1
 
 Search Everything increases WordPress' default search functionality in three easy steps.
 
@@ -115,6 +115,13 @@ Before using the plugin please read the full version of [Zemanta Terms of Servic
 
 
 == Changelog ==
+
+= 8.2.1 =
+* This fixes a problem where $terms with no elements led to broken SQL code. This is the case in a wordpress installation with woocommerce plugin installed. Searching for orders led to broken SQL code because apparently the $terms array contains no elements in this case.
+
+= 8.2 =
+* Removed external search because Zemata API doesn't seem to be available anymore which caused a fatal error on post publish
+
 = 8.1.10 =
 * Fixed an error when deprectaed function create_function() is called
 

--- a/search-everything.php
+++ b/search-everything.php
@@ -3,12 +3,12 @@
 Plugin Name: Search Everything
 Plugin URI: http://wordpress.org/plugins/search-everything/
 Description: Adds search functionality without modifying any template pages: Activate, Configure and Search. Options Include: search highlight, search pages, excerpts, attachments, drafts, comments, tags and custom fields (metadata). Also offers the ability to exclude specific pages and posts. Does not search password-protected content.
-Version: 8.2
+Version: 8.2.1
 Author: Julian Troeps, Sovrn, zemanta
 Author URI: https://www.juliantroeps.com
 */
 
-define('SE_VERSION', '8.2');
+define('SE_VERSION', '8.2.1');
 
 if (!defined('SE_PLUGIN_FILE'))
 	define('SE_PLUGIN_FILE', plugin_basename(__FILE__));

--- a/search-everything.php
+++ b/search-everything.php
@@ -278,22 +278,25 @@ class SearchEverything {
 		$terms = $this->se_get_search_terms();
 
 		// if it's not a sentance add other terms
-		$search_sql_query .= '(';
+        if (count($terms) >  0) {
+            $search_sql_query .= '(';
 
-		foreach ( $terms as $term ) {
-			$search_sql_query .= $seperator;
+            foreach ($terms as $term) {
+                $search_sql_query .= $seperator;
 
-			$esc_term = $wpdb->prepare("%s", $not_exact ? "%".$term."%" : $term);
+                $esc_term = $wpdb->prepare("%s", $not_exact ? "%" . $term . "%" : $term);
 
-			$like_title = "($wpdb->posts.post_title LIKE $esc_term)";
-			$like_post = "($wpdb->posts.post_content LIKE $esc_term)";
+                $like_title = "($wpdb->posts.post_title LIKE $esc_term)";
+                $like_post = "($wpdb->posts.post_content LIKE $esc_term)";
 
-			$search_sql_query .= "($like_title OR $like_post)";
+                $search_sql_query .= "($like_title OR $like_post)";
 
-			$seperator = ' AND ';
-		}
+                $seperator = ' AND ';
+            }
 
-		$search_sql_query .= ')';
+            $search_sql_query .= ')';
+        }
+
 		return $search_sql_query;
 	}
 


### PR DESCRIPTION
This fixes a problem where `$terms` with no elements led to broken SQL code. This is the case in a wordpress installation with woocommerce plugin installed. Searching for orders led to broken SQL code because apparently the `$terms` array contains no elements in this case.