### PR TITLE
fixed notice 'Trying to access array offset on value of type bool'

### DIFF
--- a/config.php
+++ b/config.php
@@ -16,7 +16,7 @@ function se_get_options() {
 
 	$se_options = get_option('se_options', false);
 
-	if(!$se_options || $se_meta['version'] !== SE_VERSION) {
+	if(!$se_options || !$se_meta || $se_meta['version'] !== SE_VERSION) {
 		se_upgrade();
 		$se_meta = get_option('se_meta');
 		$se_options = get_option('se_options');


### PR DESCRIPTION
Thanks for merging my pull-requests - i have one more: this fixes the notice "Trying to access array offset on value of type bool" in newer php versions.  In row 5 `$se_meta` is initialized as bool `false` and the first time`se_get_options` is called `$se_meta` is bool instead of an array.  